### PR TITLE
Makefile: thêm lại biến PREFIX, cho phép thay đổi CC và SHELL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-CC=cc
-SHELL=sh
+CC?=cc
+SHELL?=sh
+PREFIX?=/usr/local
 
 engine_name=bamboo
 engine_gui_name=ibus-setup-Bamboo.desktop


### PR DESCRIPTION
- Trước commit 4d1f713 người dùng không cần chỉ định PREFIX khi cài đặt từ source. Việc xóa PREFIX có thể làm người dùng cài đặt vào /lib và /share (không mong muốn).

- Cho phép người dùng chỉ định CC/SHELL thay thế từ command line (vd. `make CC=clang SHELL=/bin/ksh`) mà không cần chỉnh Makefile.